### PR TITLE
fix the nullpointer exception for TextureMovieEncoder.

### DIFF
--- a/core/src/main/java/com/mobiusbobs/videoprocessing/core/codec/TextureMovieEncoder.java
+++ b/core/src/main/java/com/mobiusbobs/videoprocessing/core/codec/TextureMovieEncoder.java
@@ -358,7 +358,11 @@ public class TextureMovieEncoder implements Runnable {
      */
     private void handleFrameAvailable(float[] transform, long timestampNanos) {
         if (VERBOSE) Log.d(TAG, "handleFrameAvailable tr=" + transform);
-        if (mVideoEncoder != null) mVideoEncoder.drainEncoder(false);
+        if (mVideoEncoder == null) {
+            Log.e(TAG, "mVideoEncoder is not ready yet");
+            return;
+        }
+        mVideoEncoder.drainEncoder(false);
         mFullScreen.drawFrame(mTextureId, transform);
 
         if (isRecording) {


### PR DESCRIPTION
- The crash is caused by frameAvailable called before prepareEncoder. (It will happen once in a while)
- Since prepareEncoder is not yet called, both mVideoEncoder and mFullScreen will both be null and thus cause the null pointer exception thrown.
