### PR TITLE
fix video-recording with presentationTimestamp problem which will caus…

### DIFF
--- a/core/src/main/java/com/mobiusbobs/videoprocessing/core/codec/TextureMovieEncoder.java
+++ b/core/src/main/java/com/mobiusbobs/videoprocessing/core/codec/TextureMovieEncoder.java
@@ -90,7 +90,7 @@ public class TextureMovieEncoder implements Runnable {
 
     // presentation timestamp offset
     private PTHelper ptHelper = new PTHelper();
-    private long previousPT = 0;
+    private long previousPT = -1;
 
     // Constructor
     public TextureMovieEncoder(MuxerWrapper muxerWrapper) {
@@ -369,11 +369,7 @@ public class TextureMovieEncoder implements Runnable {
         if (isRecording) {
             long currentPT = timestampNanos - ptHelper.getTimeOffsetNs();
             // block out duplicated time or wrong timestamp
-            if (previousPT != 0 && previousPT >= currentPT) {
-                if (previousPT > currentPT)
-                    Log.e(TAG, "Block out invalid timestamp " + previousPT + " > " + currentPT);
-                return;
-            }
+            if (previousPT >= currentPT) return;
             previousPT = currentPT;
 
             mInputWindowSurface.setPresentationTime(currentPT);


### PR DESCRIPTION
- the timestamp we get from surfaceTexture will have duplicate timestamps and sometimes when we write it to the muxer it will result in a previousTS > currentTS ERROR and thus cause the video to be corrupted.
- There's also rarely the case that the current timestamps from surfaceTexture is less than the previous timestamps it pass. In this case, the muxer will definitely result in previousTS > currentTS ERROR.

*Note: this will not crash the app, but it will produce a corrupted video file.
